### PR TITLE
Add staleThreshold value in connection_monitor

### DIFF
--- a/addon/subscriptions/connection_monitor.js
+++ b/addon/subscriptions/connection_monitor.js
@@ -9,6 +9,7 @@ var ConnectionMonitor = Subscription.extend({
   startedAt: null,
   pingedAt: null,
   disconnectedAt: null,
+  staleThreshold: 6
 
   reconnectAttempts: 0,
 


### PR DESCRIPTION
Thanks for porting this library to Ember. I have been building and testing against it. It works pretty well, but I noticed it wasn't reconnecting during a disconnect. Found that `staleThreshold` value was not set in the `ConnectionMonitor`. 