### PR TITLE
Added queue to consumer

### DIFF
--- a/addon/core/consumer.js
+++ b/addon/core/consumer.js
@@ -4,13 +4,33 @@ import Connection from 'ember-cable/core/connection';
 
 export default Ember.Object.extend({
   url: null,
+  queue: null,
 
   setupConnection: Ember.on('init', function() {
     this.set('subscriptions', Subscriptions.create({ consumer: this }));
     this.set('connection', Connection.create({ consumer: this }));
+    this.set('queue', []);
   }),
 
   send(data) {
-    this.get('connection').send(data);
-  }
+    this.get('queue').push(data);
+  },
+
+  queueObserver: Ember.on('init', Ember.observer('queue.[]', 'connection.connected', function() {
+    const connection = this.get('connection');
+    const queue = this.get('queue');
+
+    if (!connection || !connection.get('connected')) {
+      return;
+    }
+
+    if (Ember.isEmpty(queue)) {
+      return;
+    }
+
+    queue.forEach((data, index) => {
+      connection.send(data);
+      queue.splice(index, 1);
+    });
+  }))
 });


### PR DESCRIPTION
While using this addon I was noticed that sometimes `Failed to execute 'send' on 'WebSocket': Still in CONNECTING state.` error was happened.
That was happened when quickly toggling browser tabs, or window focus out, etc for example.
So, here is my solution. 😄 