### PR TITLE
Use === instead of .match for identifier comparison in findAll

### DIFF
--- a/addon/core/subscriptions.js
+++ b/addon/core/subscriptions.js
@@ -42,7 +42,7 @@ var Subscriptions = Ember.Object.extend({
 
   findAll(identifier) {
     return this.get('subscriptions').filter(function(item) {
-      return item.get('identifier').toLowerCase().match(identifier.toLowerCase());
+      return item.get('identifier').toLowerCase() === identifier.toLowerCase();
     });
   },
 


### PR DESCRIPTION
String.prototype.match accepts a RegExp, as documented here:
https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/match
For many strings, using match will not be a problem, unless regex'
special characters are used. The following will not be a match
with itself, because it contains the `[` and `]` characters
```javascript
var string = '{channel: "chatchannel", "rooms": ["1", "2", "3"]}'
string.match(string) // null
```

This PR replaces the `.match` with `===`.

Cheers :)