### PR TITLE
Improve docs, fix a bug with queue observer not triggering when sending messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ember-cable
 
-This addon permit to work with actioncable easily into your ember.js application.
+This add-on enables simple integration of Rails Action Cable into Ember apps.
 
 ### Installation
 run the following command from inside your ember-cli project:
@@ -36,12 +36,14 @@ export default Ember.Controller.extend({
     });
 
     // Passing Parameters to Channel
-    consumer.subscriptions.create({ channel: 'NotificationChannel', room: 'Best Room' }, {
+    const subscription = consumer.subscriptions.create({ channel: 'NotificationChannel', room: 'Best Room' }, {
       received: (data) => {
         this.updateRecord(data);
       }
     });
 
+    // Send actions to your Action Cable channel class
+    subscription.perform("your_channel_action", { hey: "hello" });
   }),
 
   updateRecord(data) {

--- a/addon/core/consumer.js
+++ b/addon/core/consumer.js
@@ -6,14 +6,14 @@ export default Ember.Object.extend({
   url: null,
   queue: null,
 
-  setupConnection: Ember.on('init', function() {
+  init() {
     this.set('subscriptions', Subscriptions.create({ consumer: this }));
     this.set('connection', Connection.create({ consumer: this }));
     this.set('queue', []);
-  }),
+  },
 
   send(data) {
-    this.get('queue').push(data);
+    this.get('queue').pushObject(data);
   },
 
   queueObserver: Ember.on('init', Ember.observer('queue.[]', 'connection.connected', function() {


### PR DESCRIPTION
- Added an example to docs where it's demonstrated how to send events to the server

- Prefer init() hooks to unit events

- Fixed a bug where `this.get('queue').push(data);` did not trigger the queue observer, changed it to `this.get('queue').pushObject(data);`