### PR TITLE
Check actual WS state in `connection.isOpen()`

### DIFF
--- a/addon/core/connection.js
+++ b/addon/core/connection.js
@@ -44,7 +44,8 @@ export default Ember.Object.extend({
   },
 
   isOpen() {
-    return Ember.isEqual(this.get('connected'), true);
+    return Ember.isEqual(this.get('connected'), true) &&
+      Ember.isEqual(this.get('webSocket').readyState, this.get('webSocket').OPEN)
   },
 
   disconnect() {


### PR DESCRIPTION
The `connection.isOpen()` checks the `WebSocket.readyState` property if it still `OPEN`. This fixes #14.