### PR TITLE
1/allow for rejection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+
+.idea/

--- a/addon/core/subscriptions.js
+++ b/addon/core/subscriptions.js
@@ -31,8 +31,10 @@ var Subscriptions = Ember.Object.extend({
   },
 
   reject(identifier) {
+    console.log("rejecting: " + identifier);
     this.findAll(identifier).forEach( (subscription) => {
-      this.sendCommand(subscription, 'rejected');
+      this.notify(subscription, "rejected");
+      // this.sendCommand(subscription, 'rejected');
     });
   },
 

--- a/addon/core/subscriptions.js
+++ b/addon/core/subscriptions.js
@@ -33,7 +33,7 @@ var Subscriptions = Ember.Object.extend({
   reject(identifier) {
     console.log("rejecting: " + identifier);
     this.findAll(identifier).forEach( (subscription) => {
-      this.forget(subscription);
+      // this.forget(subscription);
       this.notify(subscription, "rejected");
     });
   },

--- a/addon/core/subscriptions.js
+++ b/addon/core/subscriptions.js
@@ -33,8 +33,8 @@ var Subscriptions = Ember.Object.extend({
   reject(identifier) {
     console.log("rejecting: " + identifier);
     this.findAll(identifier).forEach( (subscription) => {
+      this.forget(subscription);
       this.notify(subscription, "rejected");
-      // this.sendCommand(subscription, 'rejected');
     });
   },
 

--- a/addon/core/subscriptions.js
+++ b/addon/core/subscriptions.js
@@ -74,6 +74,9 @@ var Subscriptions = Ember.Object.extend({
     } else {
       this.get('consumer').send({command, identifier});
     }
+  },
+  subs() {
+    return this.get('subscriptions');
   }
 
 });

--- a/addon/core/subscriptions.js
+++ b/addon/core/subscriptions.js
@@ -31,9 +31,8 @@ var Subscriptions = Ember.Object.extend({
   },
 
   reject(identifier) {
-    console.log("rejecting: " + identifier);
     this.findAll(identifier).forEach( (subscription) => {
-      // this.forget(subscription);
+      this.forget(subscription);
       this.notify(subscription, "rejected");
     });
   },
@@ -74,11 +73,7 @@ var Subscriptions = Ember.Object.extend({
     } else {
       this.get('consumer').send({command, identifier});
     }
-  },
-  subs() {
-    return this.get('subscriptions');
   }
-
 });
 
 Subscriptions[Ember.NAME_KEY] = 'Subscriptions';


### PR DESCRIPTION
not sure why on rejection, ember-cable tells the server that its been rejected, and still keeps the websocket open. This makes forgets the subscription on rejection and calls the rejected callback if one is specified