### PR TITLE
Don't reconnect when still connecting

### DIFF
--- a/addon/core/connection.js
+++ b/addon/core/connection.js
@@ -45,7 +45,11 @@ export default Ember.Object.extend({
 
   isOpen() {
     return Ember.isEqual(this.get('connected'), true) &&
-      Ember.isEqual(this.get('webSocket').readyState, this.get('webSocket').OPEN)
+      Ember.isEqual(this.get('webSocket').readyState, this.get('webSocket').OPEN);
+  },
+
+  isConnecting() {
+    return Ember.isEqual(this.get('webSocket').readyState, this.get('webSocket').CONNECTING);
   },
 
   disconnect() {

--- a/addon/core/connection_monitor.js
+++ b/addon/core/connection_monitor.js
@@ -60,7 +60,7 @@ var ConnectionMonitor = Ember.Object.extend({
   },
 
   connectionIsStale() {
-    return this.secondsSince(this.get('pingedAt') || this.get('startedAt')) > this.get('staleThreshold');
+    return !this.get('connection').isConnecting() && this.secondsSince(this.get('pingedAt') || this.get('startedAt')) > this.get('staleThreshold');
   },
 
   disconnectedRecently() {


### PR DESCRIPTION
This solves an issue that causes ember-cable to create duplicate connections when the connection is queueing longer then the ping interval. This causes a state where multiple connections can become alive, because old connections that were queueing aren't closed, while new ones are created.

The `WebSocket.CONNECTING` state can be handled in two ways:
- Close the previous connection and retry
- Wait until the connection either comes true or dies and then retry

This pr solves it the second way.