### PR TITLE
Close websocket when connection destroyed

### DIFF
--- a/addon/core/connection.js
+++ b/addon/core/connection.js
@@ -60,6 +60,7 @@ export default EmberObject.extend({
     this._super();
     clearTimeout(this._reopenTimer);
     this.monitor.destroy();
+    this.close();
   },
 
   isClose() {


### PR DESCRIPTION
Seems weird that there's no way to clean up after you don't need the cable any more. See e.g. https://github.com/algonauti/ember-cable/issues/12 and https://github.com/algonauti/ember-cable/issues/16.

This adds a simple method which stops the connection monitor polling to reconnect, and closes the websocket. Note that you still need to unsubscribe before calling this or you'll get the final disconnected event, which may or may not be a problem.