### PR TITLE
Remove events from webSocket when closing

### DIFF
--- a/addon/core/connection.js
+++ b/addon/core/connection.js
@@ -37,7 +37,14 @@ export default EmberObject.extend({
   },
 
   close() {
+    let ws = this.get('webSocket');
+
+    ['open', 'close', 'error', 'message'].forEach(eventName => {
+      ws[`on${eventName}`] = null;
+    });
+
     tryInvoke(get(this, 'webSocket'), 'close');
+    this.disconnect();
   },
 
   reopen() {


### PR DESCRIPTION
This attempts to resolve a very tricky bug. From the `WebSocket` specification, it follows that there are four readystates:

- `CONNECTING`
- `OPEN`
- `CLOSING`
- `CLOSED`

Now consider the following order of events:

- socket 1 connecting
- socket 1 open
- socket 1 closing
- socket 2 connecting
- socket 2 open
- socket 1 closed

We were able to reproduce this by killing the internet connection and enabling it again. The pings on socket 1 will stop, so a new socket will be created. Socket 1 however is not immediately closed. We found that at least in chrome, the browser will attempt to communicate the close to the backend, and will timeout after 30 seconds. In the meantime, it's `readyState` is `CLOSING`. Sometimes, the internet comes back right before a reconnect attempt is scheduled. In this case, the new socket is opened before the old one is finally `CLOSED`.

As the events of a killed socket are still being handled, the connection receives a close event that belongs to socket 1, while there are still messages (including pings) coming in from socket 2, which is `OPEN`. The `Connection` object now thinks it's not `connected` while it is actually still connected. This causes `send` to omit messages, as it checks for `connected`.

All in all, if the above order of events occurs, `send` no longer works.
Our proposal to fix this, is by immediately unbinding event handlers on sockets that are being given up by the frontend. We were able to reproduce the above scenario and confirmed that this fix resolves it. We're open to discuss alternative solutions.