### PR TITLE
[feat] isConnected flag can be used as computed property

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   cableService: Ember.inject.service('cable'),
+  consumer: null,
 
   setupConsumer: Ember.on('init', function() {
     var consumer = this.get('cableService').createConsumer('ws://localhost:4200/cable');
@@ -58,11 +59,20 @@ export default Ember.Controller.extend({
 
     // Send actions to your Action Cable channel class
     subscription.perform("your_channel_action", { hey: "hello" });
+
+    // Save consumer to controller to link up computed props
+    this.set('consumer', consumer);
   }),
 
   updateRecord(data) {
     Ember.debug( "updateRecord(data) -> " + Ember.inspect(data) );
-  }
+  },
+
+  // Flag indicating a connection is being attempted
+  isConnected: Ember.computed.readOnly('consumer.isConnected'),
+
+  // Milliseconds until the next connection attempt
+  nextConnectionAt: Ember.computed.readOnly('consumer.nextConnectionAt'),
 });
 
 ```

--- a/addon/core/consumer.js
+++ b/addon/core/consumer.js
@@ -1,4 +1,5 @@
 import EmberObject from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 import { getOwner } from '@ember/application';
 import { inject as service } from '@ember/service';
 import Subscriptions from 'ember-cable/core/subscriptions';
@@ -11,6 +12,9 @@ export default EmberObject.extend({
 
   // Default Values
   url: null,
+
+  isConnecting: readOnly('connection.isConnecting'),
+  nextConnectionAt: readOnly('connection.nextConnectionAt'),
 
   init() {
     this._super(...arguments);


### PR DESCRIPTION
**Why**

I wanted to be able to display socket status (connected, disconnected, connecting..., retrying in X seconds...), but could not consume `isConnected()` as a computed property to bind in a template. Also, the timestamp for when the connection would be retried was not exposed.

**Caveats**

This does replace an real-time check on the `readyState` property on the websocket. It moves the setting of the `isConnecting: true` to when the web socket is initialized via `new WebSocket(...)` and then the setting of `isConnecting: false` to when a state-change handler is run (`onerror`/`onopen`).