### PR TITLE
[fix] readme reference isConnected -> isConnecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ export default Ember.Controller.extend({
   },
 
   // Flag indicating a connection is being attempted
-  isConnected: Ember.computed.readOnly('consumer.isConnected'),
+  isConnecting: Ember.computed.readOnly('consumer.isConnecting'),
 
   // Milliseconds until the next connection attempt
   nextConnectionAt: Ember.computed.readOnly('consumer.nextConnectionAt'),


### PR DESCRIPTION
Sorry, missed this when updating the readme. Should be `isConnecting` https://github.com/algonauti/ember-cable/blob/master/addon/core/consumer.js#L16