### PR TITLE
Change rails port

### DIFF
--- a/server/proxies/cable.js
+++ b/server/proxies/cable.js
@@ -8,7 +8,7 @@ module.exports = function(app, options) {
   // For options, see:
   // https://github.com/nodejitsu/node-http-proxy
   let proxy = require('http-proxy').createProxyServer({
-    target: 'http://localhost:3006',
+    target: options.proxy || 'http://localhost:3000',
     ws: true,
     changeOrigin: true
   });

--- a/server/proxies/cable.js
+++ b/server/proxies/cable.js
@@ -8,7 +8,7 @@ module.exports = function(app, options) {
   // For options, see:
   // https://github.com/nodejitsu/node-http-proxy
   let proxy = require('http-proxy').createProxyServer({
-    target: 'http://localhost:3000',
+    target: 'http://localhost:3006',
     ws: true,
     changeOrigin: true
   });


### PR DESCRIPTION
Not everyone runs rails on port 3000. This will honors the `--proxy` argument passed to `ember serve` (and also the `proxy` property in the `.ember-cli` config file)