### PR TITLE
consumer: add reopenConnection function

### DIFF
--- a/addon/-private/consumer.js
+++ b/addon/-private/consumer.js
@@ -6,6 +6,10 @@ export default class CableConsumer extends Consumer {
     return this.connection.isOpen();
   }
 
+  reopenConnection() {
+    return this.connection.reopen();
+  }
+
   createSubscription(channelName, mixin) {
     return this.subscriptions.create(channelName, mixin);
   }


### PR DESCRIPTION
This is useful after updating the url, and prevents us from having to implement logic for delaying reconnecting after disconnecting which is already part of `@rails/actioncable`.